### PR TITLE
fix name error: replaced create_drop_zone with create_file_picker

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2733,7 +2733,7 @@ async def create_matryoshka_panel():
             refresh_carriers()
 
             # Carrier upload
-            carrier_upload_html, carrier_upload_js = create_drop_zone(
+            carrier_upload_html, carrier_upload_js = create_file_picker(
                 'matryoshka_carrier', 'image/png,image/jpeg,image/webp',
                 '/api/matryoshka/add_carrier', 'matryoshka'
             )
@@ -2809,7 +2809,7 @@ async def create_matryoshka_panel():
                 depth_slider.on('update:model-value', update_depth)
 
             # Image upload for decode
-            decode_upload_html, decode_upload_js = create_drop_zone(
+            decode_upload_html, decode_upload_js = create_file_picker(
                 'matryoshka_decode', 'image/png',
                 '/api/upload/decode', 'matryoshka'
             )


### PR DESCRIPTION
Fix NameError: create_drop_zone is not defined (Matryoshka tab)

webui.py called create_drop_zone() at lines 2736 and 2812, but the
function is named create_file_picker (line 1154) — identical signature.
Renamed both call sites. Fixes the 500 error when opening the Matryoshka
tab in stegg-web. Verified working on macOS and Windows.

Fixes #11 